### PR TITLE
Give option to vertical alignment of covers

### DIFF
--- a/source/Constants.xaml
+++ b/source/Constants.xaml
@@ -13,6 +13,7 @@
     <sys:Boolean x:Key="GridViewAllowUseOfLogos">true</sys:Boolean>
     <sys:Boolean x:Key="DetailsViewLibraryGameShowFavorite">true</sys:Boolean>
     <sys:Boolean x:Key="GridViewLibraryGameShowFavorite">true</sys:Boolean>
+    <VerticalAlignment x:Key="GridViewLibraryGameCoverVerticalAlignment">Top</VerticalAlignment>
     <sys:Boolean x:Key="GridViewShowHltbDataGrid">True</sys:Boolean>
     <sys:Boolean x:Key="GridViewEnableCoverShineAnimation">False</sys:Boolean>
     <sys:Boolean x:Key="GridViewCoverDisplayLibraryBanner">False</sys:Boolean>

--- a/source/DerivedStyles/GridViewItemTemplate.xaml
+++ b/source/DerivedStyles/GridViewItemTemplate.xaml
@@ -76,7 +76,7 @@
 
                                     <Image Name="PART_ImageCover" Grid.Row="1" Height="{Settings GridItemHeight}"
                                            RenderOptions.BitmapScalingMode="Fant" StretchDirection="Both"
-                                           HorizontalAlignment="Center" VerticalAlignment="Top"
+                                           HorizontalAlignment="Center" VerticalAlignment="{DynamicResource GridViewLibraryGameCoverVerticalAlignment}"
                                            Stretch="{Settings CoverArtStretch}" />
 
                                     <Grid Grid.RowSpan="2">

--- a/source/thememodifier.yaml
+++ b/source/thememodifier.yaml
@@ -29,6 +29,7 @@ Constants:
     - GridViewEnableCoverShineAnimation: 'Enable cover highlight animation on hover'
     - GridViewEnablePlayingGlowBorder: 'Show glow animation if game is running'
     - GridViewLibraryGameShowFavorite: 'Show favorites icon'
+    - GridViewLibraryGameCoverVerticalAlignment: 'Choose the vertival alignment of game covers'
     - GridViewCoverDisplayLibraryBanner: 'Show banners (Requires ThemeExtras extension)'
     - GridViewCoverUseRoundedCorners: 'Use rounded corners for game covers (Can cause performance degradation)'
     - GridViewCoverDisplayDropShadowEffect: 'Use dropshadow effect (Can cause performance degradation)'


### PR DESCRIPTION
I've used your theme for a long while before all covers were aligned to the top. Since this was my only complaint with it, I'm proposing a option for the user to choose the vertical alignment of the game covers with it defaulting to Top.