### PR TITLE
GridViewItemTemplate: Change to 'stop' symbol from 'play' when a game is launching or running

### DIFF
--- a/source/DerivedStyles/GridViewItemTemplate.xaml
+++ b/source/DerivedStyles/GridViewItemTemplate.xaml
@@ -126,9 +126,22 @@
                                 <Viewbox VerticalAlignment="Bottom" HorizontalAlignment="Center"
                                                  Name="GameControls"  Visibility="Collapsed">
                                     <StackPanel Orientation="Horizontal">
-                                        <Button Name="PART_ButtonPlay" Style="{StaticResource SimpleButton}"
-                                                        Margin="20,0,2,5" VerticalAlignment="Center"
-                                                        Content="&#xec74;" FontFamily="{StaticResource FontIcoFont}" />
+                                        <Button Name="PART_ButtonPlay" Margin="20,0,2,5" VerticalAlignment="Center"
+                                                        FontFamily="{StaticResource FontIcoFont}">
+                                            <Button.Style>
+												<Style TargetType="Button" BasedOn="{StaticResource SimpleButton}">
+													<Setter Property="Content" Value="&#xec74;" />
+													<Style.Triggers>
+														<DataTrigger Binding="{Binding IsLaunching}" Value="True">
+															<Setter Property="Content" Value="&#xeffc;" />
+														</DataTrigger>
+														<DataTrigger Binding="{Binding IsRunning}" Value="True">
+															<Setter Property="Content" Value="&#xeffc;" />
+														</DataTrigger>
+													</Style.Triggers>
+												</Style>
+											</Button.Style>
+                                        </Button>
                                         <Button Name="PART_ButtonInfo" Style="{StaticResource SimpleButton}"
                                                         Margin="2,0,20,5" VerticalAlignment="Center"
                                                         Content="&#xef4f;" FontFamily="{StaticResource FontIcoFont}" />


### PR DESCRIPTION
When you launch the game in grid view, it's hard to tell whether the game is actually launching because nothing happens until the game shows up in the screen. This PR addresses this by changing the icon to 'stop' symbol when the game is launching or running.

Here's how it looks:

<img width="1920" height="1018" alt="screenshot" src="https://github.com/user-attachments/assets/f0e9245d-93a1-4813-ab8c-876f538ff281" />
